### PR TITLE
Proposed new security tags

### DIFF
--- a/tag_definitions.yml
+++ b/tag_definitions.yml
@@ -110,3 +110,27 @@ tags:
   value_set: [true, false]
   creator: OLI
   version: 1.0
+
+- id: oli.is_audited
+  name: Is Audited
+  description: Link to information on security audit or audit report. Preferably uses EIP-7512.
+  type: string
+  creator: OLI
+  version: 1.0
+
+- id: oli.is_contract_monitored
+  name: Is Smart Contract Monitored
+  description: Link to information on how contract is actively by smart contract contract monitoring service.
+  type: string
+  creator: OLI
+  version: 1.0
+
+- id: oli.is_source_code_verified
+  name: Is the contract cource code verified
+  description: Link to contract source code verification, e.g. block explorer or source code verification service
+  type: string
+  creator: OLI
+  version: 1.0
+
+
+


### PR DESCRIPTION
Adding proposal for three new tags:

`oli.is_audited`

Link to a proof of audit or an audit report, preferably leveraging eip-7512

`oli.is_contract_monitored`

Is the smart contract being monitored by a monitoring service (e.g. Hexagate, Hypernative). There isn't a standard representation of this yet afaik, so this may be something we work with providers on.  Either way, the tag will be a URL.

`oli.is_source_code_verified`

Link to a block explorer / source code verification service (e.g. sourcify.dev)