### PR TITLE
remove 2 tags that of no use imo

### DIFF
--- a/tag_definitions.yml
+++ b/tag_definitions.yml
@@ -67,12 +67,6 @@ tags:
   creator: OLI
   version: 1.0
 
-# - id: oli.bytecode
-#   name: Bytecode
-#   description: The bytecode of the contract. Or link to VERA?
-#   type: string
-#   creator: OLI
-
 - id: oli.erc_type
   name: ERC Type
   description: The type of ERC standards the contract implements.
@@ -93,13 +87,6 @@ tags:
   description: The category of usage for the contract.
   type: string
   value_set: https://github.com/openlabelsinitiative/OLI/blob/main/valuesets/category_definitions.yml
-  creator: OLI
-  version: 1.0
-
-- id: oli.version
-  name: Version
-  description: The release version of the dApp (i.e. 2 for Uniswap v2 contracts).
-  type: int
   creator: OLI
   version: 1.0
 

--- a/tag_definitions.yml
+++ b/tag_definitions.yml
@@ -14,17 +14,17 @@ tags:
   creator: OLI
   version: 1.0
 
-- id: oli.is_factory_contract
-  name: Is Factory Contract
-  description: Is the address a factory contract?
+- id: oli.is_contract
+  name: Is Contract
+  description: Is the address a contract?
   type: boolean
   value_set: [true, false]
   creator: OLI
   version: 1.0
 
-- id: oli.is_contract
-  name: Is Contract
-  description: Is the address a contract?
+- id: oli.is_factory_contract
+  name: Is Factory Contract
+  description: Is the address a factory contract?
   type: boolean
   value_set: [true, false]
   creator: OLI
@@ -67,6 +67,14 @@ tags:
   creator: OLI
   version: 1.0
 
+- id: oli.is_safe_contract
+  name: Is Safe Contract
+  description: Is the address a Safe contract?
+  type: boolean
+  value_set: [true, false]
+  creator: OLI
+  version: 1.0
+
 - id: oli.erc_type
   name: ERC Type
   description: The type of ERC standards the contract implements.
@@ -90,10 +98,10 @@ tags:
   creator: OLI
   version: 1.0
 
-- id: oli.is_safe_contract
-  name: Is Safe Contract
-  description: Is the address a Safe contract?
-  type: boolean
-  value_set: [true, false]
+- id: oli.version
+  name: Version
+  description: The release version of the dApp (i.e. 2 for Uniswap v2 contracts).
+  type: int
   creator: OLI
   version: 1.0
+


### PR DESCRIPTION
* the tag `oli.bytecode` is unnecessary once we have the `oli.source_code_verified` tag (see [PR#7](https://github.com/openlabelsinitiative/OLI/pull/7)). Sourcify already has all of this data neatly stored on their end. I do not see any advantage in pulling this data here for OLI.

* this might be a little bit more controversial, but I think we should drop the `oli.version` tag. It could be misinterpreted as a way of versioning the labels. Instead, I propose always adding the version in the `oli.name` tag, e.g., RouterV2.