### PR TITLE
Change some categories around

### DIFF
--- a/1_data_model/tags/valuesets/category_definitions.yml
+++ b/1_data_model/tags/valuesets/category_definitions.yml
@@ -2,6 +2,7 @@ version: 1.0
 cefi:
   main_category_name: CeFi
   categories:
+  
   - category_id: trading
     name: Trading
     description: Contracts primarily used for automated trading strategies like arbitrage, market-making, or complex MEV exploitation, often characterized by frequent, high-volume transactions.
@@ -9,6 +10,7 @@ cefi:
       - https://basescan.org/address/0x2183998847184AF8acDDfE49D16272753D2B56fC
       - https://optimistic.etherscan.io/address/0x802b65b5d9016621E66003aeD0b16615093f328b
       - https://dashboard.tenderly.co/contract/34443/0x536688ef204ba2b035f77be1bf4b1a0dd675b266/transactions
+  
   - category_id: cex
     name: Centralized Exchange
     description: Wallets and contracts directly managed or operated by centralized exchanges (CEXs), used for deposits, withdrawals, internal transfers, or CEX-specific functions like liquidation engines.
@@ -19,36 +21,45 @@ cefi:
 defi:
   main_category_name: DeFi
   categories:
+  
   - category_id: dex
     name: Decentralized Exchange
     description: Contracts facilitating peer-to-peer token swaps using automated market makers (AMMs) and liquidity pools, allowing users to trade assets directly without intermediaries.
     examples: Uniswap Routers, Curve Pools, SushiSwap Routers.
+  
   - category_id: lending
     name: Lending
     description: Contracts allowing users to lend their crypto assets to earn interest or borrow assets by providing collateral, typically using over-collateralization mechanisms.
     examples: Aave LendingPool, Compound cToken Contracts, MakerDAO Vaults.
+  
   - category_id: derivative
     name: Derivative Exchange
     description: Contracts enabling the creation and trading of financial derivatives (like futures, options, perpetual swaps) based on underlying crypto assets or indices.
     examples: Synthetix Synths, GMX Vault, dYdX Perpetual Contracts, Perpetual Protocol Clearinghouse.
+  
   - category_id: staking
     name: Staking
     description: Contracts enabling users to lock up tokens (native, governance, or LP tokens) to secure a network, participate in governance, or earn yield. Includes direct staking contracts and liquidity pool (LP) deposit contracts.
     examples: Lido stETH (not the fungible token), Rocket Pool Staking Contracts, Uniswap V3 Positions NFT (as representation of staked LP), Curve Gauge Contracts, Convex Finance Pools.
+  
   - category_id: index
     name: Index
     description: Crypto indexes that are designed to represent the overall performance of a specific segment of the cryptocurrency market or the entire market.
+  
   - category_id: rwa
     name: Real World Assets
     description: Contracts focused on tokenizing real-world assets (like real estate, commodities, bonds) on the blockchain, enabling fractional ownership, lending, and trading of these assets.
     examples:
+  
   - category_id: insurance
     name: Insurance
     description: Contracts from protocols offering insurance coverage against specific risks in the crypto space, such as smart contract hacks, stablecoin de-pegging, or slashing events.
     examples:
+  
   - category_id: custody
     name: Custody
     description: Services involved in the secure storage and management of digital assets on behalf of individuals, institutional investors, or businesses. 
+  
   - category_id: yield_vaults
     name: Yield Vaults
     description: Contracts with automated strategies (vaults) designed to maximize returns on deposited assets by employing complex yield farming techniques across various DeFi protocols.
@@ -57,14 +68,17 @@ defi:
 nft:
   main_category_name: NFT
   categories:
+  
   - category_id: nft_fi
     name: NFT Finance
     description: Contracts from protocols bridging the gap between NFTs and DeFi, enabling financial activities like lending against NFTs as collateral, fractionalizing NFTs, or creating NFT-based derivatives.
     examples: NFTfi Lending Contracts, BendDAO, Fractional.art Vaults, Sudoswap AMM Pools.
+  
   - category_id: nft_marketplace
     name: NFT Marketplace
     description: Contracts from platforms facilitating the discovery, minting, buying, selling, and auctioning of Non-Fungible Tokens (NFTs).
     examples: OpenSea Seaport, Blur Marketplace, Foundation Marketplace, Zora Minting Contracts, Rarible Exchange.
+  
   - category_id: non_fungible_tokens
     name: Non-Fungible Tokens
     description: The core smart contracts defining specific NFT collections, adhering to standards like ERC721 (unique items) or ERC1155 (multiple copies of items).
@@ -73,18 +87,22 @@ nft:
 social:
   main_category_name: Social
   categories:
+  
   - category_id: community
     name: Community
     description: Contracts and tools fostering community building, social interaction, content creation, or decentralized social networking on the blockchain.
     examples: Lens Protocol Profile NFTs and Posts, POAP (Proof of Attendance Protocol) Contracts, Mirror.xyz Publishing Contracts, Farcaster Hub Contracts, Quest contracts from protocols like Galxe or Layer 3.
+  
   - category_id: gambling
     name: Gambling
     description: Contracts of applications where outcomes are primarily determined by chance, involving wagering crypto assets on events like dice rolls, lotteries, or prediction markets with probabilistic outcomes.
     examples: PoolTogether Prize Pools, Decentral Games ICE Poker (aspects), Augur Markets (prediction markets), Polymarket Contracts.
+  
   - category_id: gaming
     name: Gaming
     description: Contracts supporting blockchain-integrated games, managing in-game assets (NFTs), currencies (tokens), player progression, and game logic where player skill or strategy significantly influences outcomes.
     examples: Axie Infinity Contracts (Ronin), Gods Unchained Cards (Immutable X), Decentraland LAND Contracts, The Sandbox ASSET Contracts.
+  
   - category_id: governance
     name: Governance
     description: Contracts enabling decentralized decision-making processes for protocols, including token-based voting on proposals, treasury management, and parameter updates.
@@ -93,14 +111,17 @@ social:
 token_transfers:
   main_category_name: Token Transfers
   categories:
+  
   - category_id: native_transfer
     name: Native Transfer
     description: Direct transfers of a blockchain's native currency (e.g., ETH on Ethereum, MATIC on Polygon) between Externally Owned Accounts (EOAs) or contracts, not involving ERC20 or other token standards.
     examples: Standard ETH transfer between wallets, Contract interactions resulting in ETH payment (e.g., msg.value > 0).
+  
   - category_id: stablecoin
     name: Stablecoin
     description: ERC20 (or similar standard) tokens designed to maintain a stable value, typically pegged 1:1 to a fiat currency like the US Dollar. Includes algorithmic, crypto-collateralized, and fiat-backed stablecoins.
     examples: USDC Contract, USDT Contract, DAI Contract, FRAX Contract, LUSD Contract.
+  
   - category_id: fungible_tokens
     name: Fungible Tokens
     description: Standardized token contracts (primarily ERC20) representing interchangeable assets like governance tokens, utility tokens, or protocol-specific currencies. Excludes stablecoins and NFTs.
@@ -109,49 +130,61 @@ token_transfers:
 utility:
   main_category_name: Utility
   categories:
+  
   - category_id: erc4337
     name: Account Abstraction (ERC4337)
     description: Contracts implementing the ERC-4337 standard for Account Abstraction, enabling smart contract wallets with features like gas sponsorship, batch transactions, and social recovery. Includes EntryPoint, Paymaster, and Smart Account contracts.
     examples: EntryPoint Contract (Singleton), Stackup Paymasters, Biconomy Smart Accounts, Pimlico Paymasters.
+  
   - category_id: inscriptions
     name: Inscriptions
     description: Contracts and EOAs used to inscribe arbitrary data into calldata by acting as the to-address of a transaction, enabling onchain data embedding without execution.
     examples: Ethscriptions Protocol interactions, Blobscriptions minting transactions, Ordinals-style inscriptions on EVM chains.
+  
   - category_id: oracle
     name: Oracle
     description: Services providing reliable external data (e.g., asset prices, weather information, election results) to smart contracts, bridging the gap between off-chain information and on-chain logic.
     examples: Chainlink Price Feeds, Tellor Oracles, Band Protocol Oracles, Pyth Network Oracles.
+  
   - category_id: depin
     name: Decentralized Physical Infrastructure
     description: Protocols coordinating or incentivizing the deployment and operation of physical infrastructure networks (e.g., wireless networks, storage, compute power) using blockchain and tokenomics.
     examples: Helium Network Contracts (IoT/5G), Filecoin Storage Contracts, Arweave Storage Contracts, Render Network Contracts.
+  
   - category_id: developer_tools
     name: Developer Tool
     description: Contracts and infrastructure that assist developers in creating, testing, deploying and interacting with smart contracts. This includes middleware contracts that abstracts complexity, automates tasks and streamlines development workflows within one blockchain ecosystem.
+  
   - category_id: identity
     name: Identity
     description: Contracts from protocols managing decentralized digital identities, allowing users to control their personal data and enabling verification services (e.g., KYC, attestations) on-chain.
     examples: Worldcoin Identity Contracts, ENS (Ethereum Name Service - as identifier), Polygon ID Contracts, BrightID Verifications, Gitcoin Passport Stamps, EAS (Ethereum Attestation Service), Verax.
+  
   - category_id: privacy
     name: Privacy
     description: Protocols using cryptographic techniques (like zero-knowledge proofs) to obfuscate transaction details (sender, receiver, amount), enhancing user privacy on public blockchains.
     examples: Tornado Cash Contracts (historical example), Aztec Network Contracts, Railgun Privacy Contracts, Nocturne Privacy Vaults.
+  
   - category_id: airdrop
     name: Airdrop
     description: Smart contracts specifically designed to distribute tokens or NFTs to a large number of addresses simultaneously, often used for initial token distributions or community rewards.
     examples: Merkle Distributor Contracts, Disperse.app Contract, Custom airdrop claim contracts.
+  
   - category_id: payments
     name: Payments
     description: Contracts and platforms enabling streamlined or specialized payment flows, such as subscriptions, streaming payments, or payroll using cryptocurrencies.
     examples: Superfluid Finance Streams, Sablier Streams, Request Network Invoices, Utopia Payroll Contracts.
+  
   - category_id: donation
     name: Donation
     description: Platforms and contracts facilitating charitable donations and fundraising campaigns using cryptocurrencies, often providing transparency in fund allocation.
     examples: Gitcoin Grants Contracts, The Giving Block donation addresses (contract interactions), Endaoment Contracts.
+  
   - category_id: cybercrime
     name: Cybercrime
     description: Contracts involved in malicious activities, including phishing scams, rug pulls, exploit contracts used in DeFi hacks, or malware distribution via smart contracts.
     examples: Known phishing contracts (e.g., SetApprovalForAll drainers), Exploit contracts identified post-hack, Addresses associated with OFAC sanctions, Honeypot contracts.
+  
   - category_id: other
     name: Others
     description: Utility contracts that serve a specific purpose but don't neatly fit into the predefined utility categories. Use sparingly.
@@ -160,14 +193,17 @@ utility:
 cross_chain:
   main_category_name: Cross-Chain
   categories:
+  
   - category_id: cc_communication
     name: Cross-Chain Communication
     description: Protocols enabling messaging and arbitrary data transfer between different blockchains, without moving assets. Used for cross-chain state synchronization or contract calls.
     examples: LayerZero Endpoints, Axelar Gas Receiver/Gateway, L2 to L1 Communication Contracts.
+  
   - category_id: bridge
     name: Bridge
     description: Contracts facilitating the transfer of assets (tokens or NFTs) between different blockchains, typically involving locking assets on one chain and minting wrapped versions on another, or using liquidity pools for atomic swaps.
     examples: Polygon PoS Bridge, Arbitrum Bridge, Across Protocol Bridge, Synapse Protocol Bridge, Hop Protocol Bridge, Stargate Finance Pools.
+  
   - category_id: settlement
     name: Settlement & Data Availability
     description: Contracts on a Layer 1 (Ethereum) used by Layer 2 or Layer 3 scaling solutions to post transaction batches, state roots, fraud proofs, or validity proofs, ensuring data availability and inheriting security from the L1.


### PR DESCRIPTION
In this PR:

- Merged `trading` and `MEV` into a single category: `trading`. Hard to distinguish between different types of strategies for value extracting trading bots.
- Removed `Middleware`: it was too confusing when compared with categories like `developer_tooling`, `cc_communication` and `bridge`.
- Removed the `Contract Deployment` category: we already have the is_factory tag to identify factory contracts and on most EVM-based chains, contract deployments can be inferred by filtering for empty to_address fields

Open Questions:

- What would be a better name for `CeFi`?
- `payments` category pointless? No contracts are assigned there.
