### PR TITLE
Add paymaster category tag

### DIFF
--- a/1_data_model/tags/tag_definitions.yml
+++ b/1_data_model/tags/tag_definitions.yml
@@ -150,4 +150,5 @@ tags:
   name: Paymaster Category
   description: The category of paymaster contract.
   type: string
+  value_set: ['verifying', 'token', 'verifying_and_token']
   creator: OLI

--- a/1_data_model/tags/tag_definitions.yml
+++ b/1_data_model/tags/tag_definitions.yml
@@ -146,5 +146,8 @@ tags:
   type: string
   creator: OLI
 
-
-
+- tag_id: oli.paymaster_category
+  name: Paymaster Category
+  description: The category of paymaster contract.
+  type: string
+  creator: OLI

--- a/1_data_model/tags/tag_definitions.yml
+++ b/1_data_model/tags/tag_definitions.yml
@@ -152,3 +152,17 @@ tags:
   type: string
   value_set: ['verifying', 'token', 'verifying_and_token']
   creator: OLI
+
+- tag_id: oli.is_bundler
+  name: Is Bundler
+  description: Is the address an ERC-4337 bundler?
+  type: boolean
+  value_set: [true, false]
+  creator: OLI
+
+- tag_id: oli.is_paymaster
+  name: Is Paymaster
+  description: Is the address an ERC-4337 paymaster?
+  type: boolean
+  value_set: [true, false]
+  creator: OLI


### PR DESCRIPTION
Added a tag for paymaster category. Paymasters can be verifying paymasters, token paymasters or both.